### PR TITLE
modified models to fix formatting of targets API responses

### DIFF
--- a/elected_targets/models.py
+++ b/elected_targets/models.py
@@ -49,7 +49,7 @@ class Target(models.Model):
 
     def target_name(self):
         target = getattr(self, self.target_column, '')
-        return re.sub(r'(_|-0+)', '-', target)
+        return re.sub(r'(_0+|-0+|_)', '-', target)
 
     def target_type(self):
         return self._meta.db_table
@@ -231,7 +231,7 @@ class SenatememContact(models.Model):
 
 
 class Statehousemem(Target):
-    target_column = 'legislator_id'
+    target_column = 'district'
     legislator_id = models.CharField(primary_key=True, max_length=6)
     district = models.CharField(max_length=15)
     state = models.CharField(max_length=20, blank=True, null=True)
@@ -265,7 +265,7 @@ class Statehousemem(Target):
 
 
 class Statesenatemem(Target):
-    target_column = 'legislator_id'
+    target_column = 'seat'
     legislator_id = models.CharField(primary_key=True, max_length=6)
     seat = models.CharField(max_length=15)
     state = models.CharField(max_length=20, blank=True, null=True)

--- a/elected_targets/models.py
+++ b/elected_targets/models.py
@@ -266,6 +266,9 @@ class Statehousemem(Target):
     class Meta:
         db_table = 'statehousemem'
 
+    def target_name(self):
+        return re.sub(r'(_0+|-0+|_)', '-', self.district)
+
 
 class Statesenatemem(Target):
     target_column = 'legislator_id'
@@ -303,6 +306,9 @@ class Statesenatemem(Target):
 
     class Meta:
         db_table = 'statesenatemem'
+
+    def target_name(self):
+        return re.sub(r'(_0+|-0+|_)', '-', self.seat)
 
 
 class ZipStateBodyDistrict(models.Model):

--- a/elected_targets/models.py
+++ b/elected_targets/models.py
@@ -50,6 +50,9 @@ class Target(models.Model):
     def target_name(self):
         target = getattr(self, self.target_column, '')
         return re.sub(r'(_0+|-0+|_)', '-', target)
+        # first replace any instances of _0, _00, _000, etc
+        # then replace any remaining instances of -0, -00, -00, etc
+        # finally replace any remaining instances of _
 
     def target_type(self):
         return self._meta.db_table
@@ -231,7 +234,7 @@ class SenatememContact(models.Model):
 
 
 class Statehousemem(Target):
-    target_column = 'district'
+    target_column = 'legislator_id'
     legislator_id = models.CharField(primary_key=True, max_length=6)
     district = models.CharField(max_length=15)
     state = models.CharField(max_length=20, blank=True, null=True)
@@ -265,7 +268,7 @@ class Statehousemem(Target):
 
 
 class Statesenatemem(Target):
-    target_column = 'seat'
+    target_column = 'legislator_id'
     legislator_id = models.CharField(primary_key=True, max_length=6)
     seat = models.CharField(max_length=15)
     state = models.CharField(max_length=20, blank=True, null=True)

--- a/elected_targets/tests.py
+++ b/elected_targets/tests.py
@@ -16,7 +16,7 @@ class ElectedTargetsTestCase(TestCase):
         test_targets = {
             '22466': ('Statesenatemem','CO-20'),
             '22467': ('Statesenatemem','CO-20'),
-            '40362': ('Statehousemem', 'CO-2'),
+            '040362': ('Statehousemem', 'CO-2'),
             'GA_1': ('Senatemem', 'GA-1'),
             'GA_01': ('Housemem','GA-1'),
         }

--- a/elected_targets/tests.py
+++ b/elected_targets/tests.py
@@ -1,0 +1,27 @@
+from django.test import Client, TestCase, override_settings
+
+from elected_targets import models
+
+TESTSETTINGS = {
+    'DEBUG': True,
+}
+
+@override_settings(**TESTSETTINGS)
+class ElectedTargetsTestCase(TestCase):
+
+    fixtures = ['test_fixture_targets']
+
+    def test_target_formatting(self):
+        # verify that the regex formatting for target_name works
+        test_targets = {
+            '22466': ('Statesenatemem','CO-20'),
+            '22467': ('Statesenatemem','CO-20'),
+            '40362': ('Statehousemem', 'CO-2'),
+            'GA_1': ('Senatemem', 'GA-1'),
+            'GA_01': ('Housemem','GA-1'),
+        }
+
+        for key, value in test_targets.items():
+            target = getattr(models, value[0]).objects.get(pk=key)
+            self.assertEquals(target.target_name(), value[1])
+


### PR DESCRIPTION
Fixed the regex on target_names to account for cases like "CO_002".
Updated target_id to pull the fields we need to format the new target search API results the same way the old API results are formatted. Alternatively, we could leave elected_targets the way it was and change the MOP target search API to grab different data.
Anyway, all this does is change the formatting of state legislator items in the target search field of the petition creation from from "Senator Cat Cats (12345)" to "Senator Cat Cats (CO-42)". 